### PR TITLE
ECS passthrough no rely on resolved enrich at runtime

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,26 +12,3 @@ $: << File.realpath(File.join(File.dirname(__FILE__), "..", "lib"))
 RSpec.configure do |config|
   config.order = :rand
 end
-
-module SpecHelper
-
-  def self.es_major_version
-    es_version.split('.').first
-  end
-
-  def self.es_version
-    [
-      nilify(RSpec.configuration.filter[:es_version]),
-      nilify(ENV['ES_VERSION']),
-      nilify(ENV['ELASTIC_STACK_VERSION']),
-    ].compact.first
-  end
-
-  private
-  def self.nilify(str)
-    if str.nil?
-      return str
-    end
-    str.empty? ? nil : str
-  end
-end


### PR DESCRIPTION
Using the resolved `@enrich` as a source-of-truth is not compatible with also accepting the deprecated flags that controlled a subset of the behaviour. By resolving the _combination_ of the enrich param with the deprecated settings using only local variables during registration into effectively-final ivars, we remove overhead of checking the flag per-event and remove the possibility that code would fail to respect an enrichment that can still be controlled by a deprecated flag.

We then break the specs into sharable components, each of which can validate whether the enrichment is effectively enabled or disabled, and separately validate the no-explicit `enrich` configuration in the presence of the deprecated flags, and use those components to validate that a fully-registered plugin is actually configured as-specified.
